### PR TITLE
pydoctest does not work from quality_control

### DIFF
--- a/quality_control/static_checks/pydoctest.json
+++ b/quality_control/static_checks/pydoctest.json
@@ -1,6 +1,6 @@
 {
     "parser": "google",
-    "include_paths": [ "../../**/*.py" ],
+    "include_paths": [ "**/*.py" ],
     "exclude_paths": [
         "**/*_stub.py",
         "**/service.py",

--- a/quality_control/static_checks/pydoctest.json
+++ b/quality_control/static_checks/pydoctest.json
@@ -1,6 +1,6 @@
 {
     "parser": "google",
-    "include_paths": [ "**/*.py" ],
+    "include_paths": [ "../**/*.py" ],
     "exclude_paths": [
         "**/*_stub.py",
         "**/service.py",


### PR DESCRIPTION
Fix pydoctest configuration

- Changed include_paths from "../../**/*.py" to "../**/*.py"
- Fixed path resolution when running from quality_control directory