### PR TITLE
fix for the need_iml default

### DIFF
--- a/quality_control/project_config.py
+++ b/quality_control/project_config.py
@@ -138,6 +138,15 @@ class ProjectConfig(ProjectConfigDTO):
         if include_addons:
             labs_list.extend(self.get_addons_names())
         return [root_dir / lab for lab in labs_list]
+    
+    def get_labs(self) -> list[Lab]:
+        """
+        Get the list of Lab objects from the configuration.
+
+        Returns:
+            list[Lab]: List of configured labs.
+        """
+        return self._dto.labs
 
     def get_addons_names(self) -> list:
         """
@@ -147,6 +156,15 @@ class ProjectConfig(ProjectConfigDTO):
             list: Addons names
         """
         return [addon.name for addon in self._dto.addons]
+    
+    def get_addons(self) -> list[Addon]:
+        """
+        Get the list of Addon objects from the configuration.
+
+        Returns:
+            list[Addon]: List of configured addons.
+        """
+        return self._dto.addons
 
     def get_admins(self) -> list[str]:
         """

--- a/quality_control/project_config.py
+++ b/quality_control/project_config.py
@@ -139,15 +139,6 @@ class ProjectConfig(ProjectConfigDTO):
             labs_list.extend(self.get_addons_names())
         return [root_dir / lab for lab in labs_list]
 
-    def get_labs(self) -> list[Lab]:
-        """
-        Get the list of Lab objects from the configuration.
-
-        Returns:
-            list[Lab]: List of configured labs.
-        """
-        return self._dto.labs
-
     def get_addons_names(self) -> list:
         """
         Get addons names.
@@ -156,15 +147,6 @@ class ProjectConfig(ProjectConfigDTO):
             list: Addons names
         """
         return [addon.name for addon in self._dto.addons]
-
-    def get_addons(self) -> list[Addon]:
-        """
-        Get the list of Addon objects from the configuration.
-
-        Returns:
-            list[Addon]: List of configured addons.
-        """
-        return self._dto.addons
 
     def get_admins(self) -> list[str]:
         """

--- a/quality_control/project_config.py
+++ b/quality_control/project_config.py
@@ -138,7 +138,7 @@ class ProjectConfig(ProjectConfigDTO):
         if include_addons:
             labs_list.extend(self.get_addons_names())
         return [root_dir / lab for lab in labs_list]
-    
+
     def get_labs(self) -> list[Lab]:
         """
         Get the list of Lab objects from the configuration.
@@ -156,7 +156,7 @@ class ProjectConfig(ProjectConfigDTO):
             list: Addons names
         """
         return [addon.name for addon in self._dto.addons]
-    
+
     def get_addons(self) -> list[Addon]:
         """
         Get the list of Addon objects from the configuration.

--- a/quality_control/project_config.py
+++ b/quality_control/project_config.py
@@ -45,7 +45,7 @@ class Addon:
 
     name: str = field(default_factory=str)
     coverage: int = field(default_factory=int)
-    need_uml: bool = field(default_factory=False)
+    need_uml: bool = False
 
 
 @dataclass


### PR DESCRIPTION
I made a mistake: the line `need_uml: bool = field(default_factory=False)` does not work